### PR TITLE
Realms should not auto sort arrays.

### DIFF
--- a/templates/krb5.conf.erb
+++ b/templates/krb5.conf.erb
@@ -69,11 +69,11 @@ default_tgs_enctypes = <%= @default_tgs_enctypes %>
 <% if @realms -%>
 
 [realms]
-<%   @realms.sort.each do |key, hash| -%>
+<%   @realms.each do |key, hash| -%>
 <%= key %> = {
-<%     hash.sort.each do |option, values| -%>
+<%     hash.each do |option, values| -%>
 <%       if values.is_a?(Array) -%>
-<%         values.sort.each do |value| -%>
+<%         values.each do |value| -%>
   <%= option %> = <%= value %>
 <%       end -%>
 <%       else -%>


### PR DESCRIPTION
The sorting causes issues when trying set a specified order of kdc server.

Example:
We want 
krb5::realms:
  kdc:
    - c <- closest
    - b <- closer
    - a <- far away

Sorting changes this to [a, b, c], which is not the desired state.

