### PR TITLE
Refactor tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,137 @@
+---
+require:
+- rubocop-rspec
+- rubocop-i18n
+AllCops:
+  DisplayCopNames: true
+  TargetRubyVersion: '2.1'
+  Include:
+  - "./**/*.rb"
+  Exclude:
+  - bin/*
+  - ".vendor/**/*"
+  - "**/Gemfile"
+  - "**/Rakefile"
+  - pkg/**/*
+  - spec/fixtures/**/*
+  - vendor/**/*
+  - "**/Puppetfile"
+  - "**/Vagrantfile"
+  - "**/Guardfile"
+Metrics/LineLength:
+  Description: People have wide screens, use them.
+  Max: 200
+GetText:
+  Enabled: false
+GetText/DecorateString:
+  Description: We don't want to decorate test output.
+  Exclude:
+  - spec/**/*
+  Enabled: false
+RSpec/BeforeAfterAll:
+  Description: Beware of using after(:all) as it may cause state to leak between tests.
+    A necessary evil in acceptance testing.
+  Exclude:
+  - spec/acceptance/**/*.rb
+RSpec/HookArgument:
+  Description: Prefer explicit :each argument, matching existing module's style
+  EnforcedStyle: each
+Style/BlockDelimiters:
+  Description: Prefer braces for chaining. Mostly an aesthetical choice. Better to
+    be consistent then.
+  EnforcedStyle: braces_for_chaining
+Style/BracesAroundHashParameters:
+  Description: Braces are required by Ruby 2.7. Cop removed from RuboCop v0.80.0.
+    See https://github.com/rubocop-hq/rubocop/pull/7643
+  Enabled: true
+Style/ClassAndModuleChildren:
+  Description: Compact style reduces the required amount of indentation.
+  EnforcedStyle: compact
+Style/EmptyElse:
+  Description: Enforce against empty else clauses, but allow `nil` for clarity.
+  EnforcedStyle: empty
+Style/FormatString:
+  Description: Following the main puppet project's style, prefer the % format format.
+  EnforcedStyle: percent
+Style/FormatStringToken:
+  Description: Following the main puppet project's style, prefer the simpler template
+    tokens over annotated ones.
+  EnforcedStyle: template
+Style/Lambda:
+  Description: Prefer the keyword for easier discoverability.
+  EnforcedStyle: literal
+Style/RegexpLiteral:
+  Description: Community preference. See https://github.com/voxpupuli/modulesync_config/issues/168
+  EnforcedStyle: percent_r
+Style/TernaryParentheses:
+  Description: Checks for use of parentheses around ternary conditions. Enforce parentheses
+    on complex expressions for better readability, but seriously consider breaking
+    it up.
+  EnforcedStyle: require_parentheses_when_complex
+Style/TrailingCommaInArguments:
+  Description: Prefer always trailing comma on multiline argument lists. This makes
+    diffs, and re-ordering nicer.
+  EnforcedStyleForMultiline: comma
+Style/TrailingCommaInLiteral:
+  Description: Prefer always trailing comma on multiline literals. This makes diffs,
+    and re-ordering nicer.
+  EnforcedStyleForMultiline: comma
+Style/SymbolArray:
+  Description: Using percent style obscures symbolic intent of array's contents.
+  EnforcedStyle: brackets
+RSpec/MessageSpies:
+  EnforcedStyle: receive
+Style/Documentation:
+  Exclude:
+  - lib/puppet/parser/functions/**/*
+  - spec/**/*
+Style/WordArray:
+  EnforcedStyle: brackets
+Style/CollectionMethods:
+  Enabled: true
+Style/MethodCalledOnDoEndBlock:
+  Enabled: true
+Style/StringMethods:
+  Enabled: true
+GetText/DecorateFunctionMessage:
+  Enabled: false
+GetText/DecorateStringFormattingUsingInterpolation:
+  Enabled: false
+GetText/DecorateStringFormattingUsingPercent:
+  Enabled: false
+Layout/EndOfLine:
+  Enabled: false
+Layout/IndentHeredoc:
+  Enabled: false
+Metrics/AbcSize:
+  Enabled: false
+Metrics/BlockLength:
+  Enabled: false
+Metrics/ClassLength:
+  Enabled: false
+Metrics/CyclomaticComplexity:
+  Enabled: false
+Metrics/MethodLength:
+  Enabled: false
+Metrics/ModuleLength:
+  Enabled: false
+Metrics/ParameterLists:
+  Enabled: false
+Metrics/PerceivedComplexity:
+  Enabled: false
+RSpec/DescribeClass:
+  Enabled: false
+RSpec/ExampleLength:
+  Enabled: false
+RSpec/MessageExpectation:
+  Enabled: false
+RSpec/MultipleExpectations:
+  Enabled: false
+RSpec/NestedGroups:
+  Enabled: false
+Style/AsciiComments:
+  Enabled: false
+Style/IfUnlessModifier:
+  Enabled: false
+Style/SymbolProc:
+  Enabled: false

--- a/README-RUBOCOP.txt
+++ b/README-RUBOCOP.txt
@@ -1,0 +1,9 @@
+Rubocop is used with setting taken from PDK 1.18.0. See .rubocop.yml for details.
+
+
+For rubocop on ruby 2.1.9 you need to install rubocop 0.49.1 with these commands:
+
+gem install rubocop -v 0.49.1
+gem install rubocop-i18n -v 1.2.0
+gem install rubocop-rspec -v 1.16.0
+

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,7 +48,7 @@ class krb5 (
           }
           default: {
             $package_real = undef
-            fail('Default packages defined for only SunOS 5.10 and 5.11. Please specify the krb5 packages in hiera')
+            fail("krb5 only supports default package names for Solaris 5.10 and 5.11. Detected kernelrelease is <${::kernelrelease}>. Please specify package name with the \$package variable.")
           }
         }
       }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,199 +1,115 @@
 require 'spec_helper'
+describe 'krb5', type: :class do
+  # define os specific defaults
+  platforms = {
+    'RedHat' => {
+      osfamily: 'RedHat',
+      package:  ['krb5-libs', 'krb5-workstation'],
+    },
+    'Suse' => {
+      osfamily: 'Suse',
+      package:  ['krb5', 'krb5-client'],
+    },
+    'Debian' => {
+      osfamily: 'Debian',
+      package:  ['krb5-user'],
+    },
+    'Solaris 5.10' => {
+      osfamily:      'Solaris',
+      kernelrelease: '5.10',
+      package:       ['SUNWkrbr', 'SUNWkrbu'],
+    },
+    'Solaris 5.11' => {
+      osfamily:      'Solaris',
+      kernelrelease: '5.11',
+      package:       ['pkg:/service/security/kerberos-5'],
+    },
+  }
 
-describe 'krb5' do
+  krb5conf_default_content = <<-END.gsub(%r{^\s+\|}, '')
+    |#Managed by puppet, any changes will be overwritten
+    |
+    |[logging]
+    |default = FILE:/var/log/krb5libs.log
+    |kdc = FILE:/var/log/krb5kdc.log
+    |admin_server = FILE:/var/log/kadmind.log
+  END
 
-  context 'with defaults for all parameters on RedHat' do
-    let(:facts) do { :osfamily => 'RedHat', } end
-    it { should contain_class('krb5') }
-    it { should contain_package('krb5-libs') }
-    it { should contain_package('krb5-workstation') }
-    it { should contain_file('krb5conf').with({
-      'path'   => '/etc/krb5.conf',
-      'ensure' => 'present',
-      'owner'  => 'root',
-      'group'  => 'root',
-      'mode'   => '0644',
-    }) }
+  describe 'with default values for parameters' do
+    platforms.sort.each do |k, v|
+      context "where OS is <#{k}>" do
+        let :facts do
+          {
+            osfamily:      v[:osfamily],
+            kernelrelease: v[:kernelrelease],
+          }
+        end
 
-    krb5conf_fixture = File.read(fixtures("krb5.conf.defaults"))
-    it { should contain_file('krb5conf').with_content(krb5conf_fixture) }
-    it { should_not contain_file('krb5keytab_file') }
+        it { is_expected.to contain_class('krb5') }
+
+        v[:package].each do |package|
+          it { is_expected.to contain_package(package).only_with_ensure('present') }
+        end
+
+        it do
+          is_expected.to contain_file('krb5conf').only_with(
+            'ensure'  => 'present',
+            'path'    => '/etc/krb5.conf',
+            'owner'   => 'root',
+            'group'   => 'root',
+            'mode'    => '0644',
+            'content' => krb5conf_default_content,
+          )
+        end
+
+        if v[:osfamily] == 'Solaris'
+          it do
+            is_expected.to contain_file('krb5directory').only_with(
+              'ensure' => 'directory',
+              'path'   => '/etc/krb5',
+              'owner'  => 'root',
+              'group'  => 'root',
+            )
+          end
+
+          it do
+            is_expected.to contain_file('krb5link').only_with(
+              'ensure'  => 'link',
+              'path'    => '/etc/krb5/krb5.conf',
+              'target'  => '/etc/krb5.conf',
+              'require' => 'File[krb5directory]',
+            )
+          end
+        else
+          it { is_expected.not_to contain_file('krb5directory') }
+          it { is_expected.not_to contain_file('krb5link') }
+        end
+        it { is_expected.not_to contain_file('krb5keytab_file') }
+      end
+    end
   end
 
-  context 'with defaults for all parameters on Suse' do
-    let(:facts) do { :osfamily => 'Suse', } end
-    it { should contain_class('krb5') }
-    it { should contain_package('krb5') }
-    it { should contain_package('krb5-client') }
-    it { should contain_file('krb5conf').with({
-      'path'   => '/etc/krb5.conf',
-      'ensure' => 'present',
-      'owner'  => 'root',
-      'group'  => 'root',
-      'mode'   => '0644',
-    }) }
-
-    krb5conf_fixture = File.read(fixtures("krb5.conf.defaults"))
-    it { should contain_file('krb5conf').with_content(krb5conf_fixture) }
-    it { should_not contain_file('krb5keytab_file') }
-  end
-
-  context 'with default params on osfamily Solaris kernelrelease 5.8' do
-    let :facts do
+  context 'with all parameters set to valid values where OS is RedHat' do
+    let :params do
       {
-        :osfamily      => 'Solaris',
-        :kernelrelease => '5.8',
-      }
-    end
-    it 'should fail' do
-      expect {
-        should contain_class('krb5')
-}.to raise_error(Puppet::Error,/Default packages defined for only SunOS 5\.10 and 5\.11\. Please specify the krb5 packages in hiera/)
-    end
-  end
-
-  context 'with default params on osfamily Solaris kernelrelease 5.11' do
-    let :facts do
-      {
-        :osfamily      => 'Solaris',
-        :kernelrelease => '5.11',
-      }
-    end
-    let(:params) do
-      {
-        :package_provider  => 'pkg',
-      }
-    end
-    it { should contain_class('krb5') }
-    it {
-      should contain_package('pkg:/service/security/kerberos-5').with({
-        'provider'  => 'pkg',
-      })
-    }
-    it { should contain_file('krb5conf').with({
-      'path'   => '/etc/krb5.conf',
-      'ensure' => 'present',
-      'owner'  => 'root',
-      'group'  => 'root',
-      'mode'   => '0644',
-    }) }
-    it { should contain_file('krb5directory').with({
-      'path'   => '/etc/krb5',
-      'ensure' => 'directory',
-      'owner'  => 'root',
-      'group'  => 'root',
-    }) }
-    it { should contain_file('krb5link').with({
-      'path'   => '/etc/krb5/krb5.conf',
-      'ensure' => 'link',
-      'target' => '/etc/krb5.conf',
-    }) }
-    krb5conf_fixture = File.read(fixtures("krb5.conf.defaults"))
-    it { should contain_file('krb5conf').with_content(krb5conf_fixture) }
-  end
-
-  context 'with default params on osfamily Solaris kernelrelease 5.10' do
-    let :facts do
-      {
-        :osfamily      => 'Solaris',
-        :kernelrelease => '5.10',
-      }
-    end
-    let(:params) do
-      { :package_adminfile => '/sw/Solaris/Sparc/noask',
-        :package_provider  => 'sun',
-        :package_source    => '/sw/Solaris/Sparc/krb/krb-x.xx-sol10-sparc',
-      }
-    end
-    it { should contain_class('krb5') }
-    it {
-      should contain_package('SUNWkrbr').with({
-        'adminfile' => '/sw/Solaris/Sparc/noask',
-        'provider'  => 'sun',
-        'source'    => '/sw/Solaris/Sparc/krb/krb-x.xx-sol10-sparc',
-      })
-    }
-    it {
-      should contain_package('SUNWkrbu').with({
-        'adminfile' => '/sw/Solaris/Sparc/noask',
-        'provider'  => 'sun',
-        'source'    => '/sw/Solaris/Sparc/krb/krb-x.xx-sol10-sparc',
-      })
-    }
-    it { should contain_file('krb5conf').with({
-      'path'   => '/etc/krb5.conf',
-      'ensure' => 'present',
-      'owner'  => 'root',
-      'group'  => 'root',
-      'mode'   => '0644',
-    }) }
-    it { should contain_file('krb5directory').with({
-      'path'   => '/etc/krb5',
-      'ensure' => 'directory',
-      'owner'  => 'root',
-      'group'  => 'root',
-    }) }
-    it { should contain_file('krb5link').with({
-      'path'   => '/etc/krb5/krb5.conf',
-      'ensure' => 'link',
-      'target' => '/etc/krb5.conf',
-    }) }
-    krb5conf_fixture = File.read(fixtures("krb5.conf.defaults"))
-    it { should contain_file('krb5conf').with_content(krb5conf_fixture) }
-    it { should_not contain_file('krb5keytab_file') }
-  end
-
-  context 'on unsupported osfamily' do
-    let(:facts) do { :osfamily => 'unsupported', } end
-    it 'should fail' do
-      expect {
-        should contain_class('krb5')
-      }.to raise_error(Puppet::Error,/krb5 only supports default package names for/)
-    end
-  end
-
-  context 'on unsupported osfamily with package set' do
-    let(:facts) do { :osfamily => 'unsupported', } end
-    let(:params) do { :package => 'krb5-package', } end
-    it { should contain_class('krb5') }
-    it { should contain_package('krb5-package') }
-    it { should contain_file('krb5conf').with({
-      'path'   => '/etc/krb5.conf',
-      'ensure' => 'present',
-      'owner'  => 'root',
-      'group'  => 'root',
-      'mode'   => '0644',
-    }) }
-
-    krb5conf_fixture = File.read(fixtures("krb5.conf.defaults"))
-    it { should contain_file('krb5conf').with_content(krb5conf_fixture) }
-    it { should_not contain_file('krb5keytab_file') }
-  end
-
-  context 'with all parameters set' do
-    let(:facts) { { :osfamily => 'RedHat' } }
-    let(:params) do
-      { :logging_default        => 'FILE:/tmp/log1',
-        :logging_kdc            => 'FILE:/tmp/log2',
-        :logging_admin_server   => 'FILE:/tmp/log3',
-        :logging_krb524d        => 'FILE:/tmp/log4',
-        :default_realm          => 'EXAMPLE.COM',
-        :dns_lookup_realm       => 'false',
-        :dns_lookup_kdc         => 'false',
-        :ticket_lifetime        => '24h',
-        :default_ccache_name    => 'FILE:/tmp/krb5cc_%{uid}',
-        :default_keytab_name    => '/etc/opt/quest/vas/host.keytab',
-        :forwardable            => 'true',
-        :allow_weak_crypto      => 'false',
-        :proxiable              => 'true',
-        :rdns                   => 'false',
-        :default_tkt_enctypes   => 'aes256-cts',
-        :default_tgs_enctypes   => 'aes128-cts',
-        :realms                 => {
+        logging_default:      'FILE:/tmp/log1',
+        logging_kdc:          'FILE:/tmp/log2',
+        logging_admin_server: 'FILE:/tmp/log3',
+        logging_krb524d:      'FILE:/tmp/log4',
+        default_realm:        'EXAMPLE.COM',
+        dns_lookup_realm:     'false',
+        dns_lookup_kdc:       'false',
+        ticket_lifetime:      '24h',
+        default_ccache_name:  'FILE:/tmp/krb5cc_%{uid}',
+        default_keytab_name:  '/etc/opt/quest/vas/host.keytab',
+        forwardable:          'true',
+        allow_weak_crypto:    'false',
+        proxiable:            'true',
+        realms: {
           'EXAMPLE.COM'         => {
             'default_domain'    => 'example.com',
-            'kdc'               => [ 'kdc1.example.com:88', 'kdc2.example.com:88', ],
-            'admin_server'      => [ 'kdc1.example.com:749', 'kdc2.example.com:749', ],
+            'kdc'               => ['kdc1.example.com:88', 'kdc2.example.com:88'],
+            'admin_server'      => ['kdc1.example.com:749', 'kdc2.example.com:749'],
           },
           'ANOTHER.EXAMPLE.COM' => {
             'default_domain'    => 'another.example.com',
@@ -201,7 +117,7 @@ describe 'krb5' do
             'admin_server'      => 'kdc1.another.example.com:749',
           },
         },
-        :appdefaults            => {
+        appdefaults: {
           'pam'                 => {
             'debug'             => 'false',
             'ticket_lifetime'   => '36000',
@@ -210,81 +126,528 @@ describe 'krb5' do
             'krb4_convert'      => 'false',
           },
         },
-        :domain_realm           => {
-          'example.com'         => 'EXAMPLE.COM',
+        domain_realm: {
+          'example.com' => 'EXAMPLE.COM',
         },
-        :package                => 'krb5-package',
-        :krb5conf_file          => '/etc/kerberos/krb5.conf',
-        :krb5conf_ensure        => 'file',
-        :krb5conf_owner         => 'kerberos',
-        :krb5conf_group         => 'kerberos',
-        :krb5conf_mode          => '0600',
-        :krb5key_link_target    => '/etc/opt/authenicationservice/key.keytab'
+        rdns:                 'false',
+        default_tkt_enctypes: 'aes256-cts',
+        default_tgs_enctypes: 'aes128-cts',
+        package:              'krb5-package-testing',
+        package_adminfile:    'Solaris specific',
+        package_provider:     'Solaris specific',
+        package_source:       'Solaris specific',
+        krb5conf_file:        '/etc/testing/krb5.conf',
+        krb5conf_ensure:      'file',
+        krb5conf_owner:       'tester_owner',
+        krb5conf_group:       'tester_group',
+        krb5conf_mode:        '0242',
+        krb5key_link_target:  '/etc/opt/authenicationservice/key.keytab',
       }
     end
 
-    it { should contain_class('krb5') }
-    it { should contain_package('krb5-package') }
-    it { should contain_file('krb5conf').with({
-      'path'   => '/etc/kerberos/krb5.conf',
-      'ensure' => 'file',
-      'owner'  => 'kerberos',
-      'group'  => 'kerberos',
-      'mode'   => '0600',
-    }) }
+    it { is_expected.to contain_package('krb5-package-testing') }
 
-    krb5conf_fixture = File.read(fixtures("krb5.conf.allset"))
-    it { should contain_file('krb5conf').with_content(krb5conf_fixture) }
-    it { should contain_file('krb5keytab_file').with({
-      'ensure' => 'link',
-      'path'   => '/etc/krb5.keytab',
-      'target' => '/etc/opt/authenicationservice/key.keytab',
-    }) }
+    it do
+      is_expected.to contain_file('krb5conf').only_with(
+        'ensure'  => 'file',
+        'path'    => '/etc/testing/krb5.conf',
+        'owner'   => 'tester_owner',
+        'group'   => 'tester_group',
+        'mode'    => '0242',
+        'content' => File.read(fixtures('krb5.conf.allset')),
+      )
+    end
+
+    it { is_expected.not_to contain_file('krb5directory') }
+    it { is_expected.not_to contain_file('krb5link') }
+
+    it {
+      is_expected.to contain_file('krb5keytab_file').only_with(
+        'ensure' => 'link',
+        'path'   => '/etc/krb5.keytab',
+        'target' => '/etc/opt/authenicationservice/key.keytab',
+      )
+    }
+  end
+
+  context 'Solaris specific params and functionalities' do
+    let :facts do
+      {
+        osfamily:      'Solaris',
+        kernelrelease: '5.11',
+      }
+    end
+
+    context 'package_adminfile set to valid value' do
+      let(:params) { { package_adminfile: '/sw/Solaris/Sparc/noask' } }
+
+      it { is_expected.to contain_package('pkg:/service/security/kerberos-5').with_adminfile('/sw/Solaris/Sparc/noask') }
+    end
+
+    context 'package_provider set to valid value' do
+      let(:params) { { package_provider: 'sun' } }
+
+      it { is_expected.to contain_package('pkg:/service/security/kerberos-5').with_provider('sun') }
+    end
+
+    context 'package_source set to valid value' do
+      let(:params) { { package_source: '/sw/Solaris/Sparc/krb/krb-x.xx-sol10-sparc' } }
+
+      it { is_expected.to contain_package('pkg:/service/security/kerberos-5').with_source('/sw/Solaris/Sparc/krb/krb-x.xx-sol10-sparc') }
+    end
+
+    context 'with krb5conf_file parameter set to /test/ing' do
+      let(:params) { { krb5conf_file: '/test/ing' } }
+
+      it { is_expected.to contain_file('krb5conf').with_path('/test/ing') }
+      it { is_expected.to contain_file('krb5link').with_target('/test/ing') }
+    end
+    context 'with krb5conf_owner parameter set to tester' do
+      let(:params) { { krb5conf_owner: 'tester' } }
+
+      it { is_expected.to contain_file('krb5conf').with_owner('tester') }
+      it { is_expected.to contain_file('krb5directory').with_owner('tester') }
+    end
+
+    context 'with krb5conf_group parameter set to tester' do
+      let(:params) { { krb5conf_group: 'tester' } }
+
+      it { is_expected.to contain_file('krb5conf').with_group('tester') }
+      it { is_expected.to contain_file('krb5directory').with_group('tester') }
+    end
+  end
+
+  context 'with logging defaults disabled (logging_default, logging_kdc, and logging_admin_server parameters are unset (empty strings))' do
+    let :params do
+      {
+        logging_default:      '',
+        logging_kdc:          '',
+        logging_admin_server: '',
+      }
+    end
+
+    it do
+      is_expected.to contain_file('krb5conf').with_content(
+        %r{^#Managed by puppet, any changes will be overwritten\n$},
+      )
+    end
+  end
+
+  context 'with logging_default parameter only set (logging_kdc and logging_admin_server are unset (empty strings))' do
+    let :params do
+      {
+        logging_default:      'FILE:/var/logging/default_only.log',
+        logging_kdc:          '',
+        logging_admin_server: '',
+      }
+    end
+
+    it do
+      is_expected.to contain_file('krb5conf').with_content(
+        %r{^#Managed by puppet, any changes will be overwritten$\n\n\[logging\]\ndefault = FILE:\/var\/logging\/default_only.log\n$},
+      )
+    end
+  end
+
+  context 'with logging_kdc parameter only set (logging_default and logging_admin_server are unset (empty strings))' do
+    let :params do
+      {
+        logging_default:      '',
+        logging_kdc:          'FILE:/var/logging/kdc_only.log',
+        logging_admin_server: '',
+      }
+    end
+
+    it do
+      is_expected.to contain_file('krb5conf').with_content(
+        %r{^#Managed by puppet, any changes will be overwritten$\n\n\[logging\]\nkdc = FILE:\/var\/logging\/kdc_only.log\n$},
+      )
+    end
+  end
+
+  context 'with logging_admin_server parameter only set (logging_default and logging_kdc are unset (empty strings))' do
+    let :params do
+      {
+        logging_default:      '',
+        logging_kdc:          '',
+        logging_admin_server: 'FILE:/var/logging/admin_server_only.log',
+      }
+    end
+
+    it do
+      is_expected.to contain_file('krb5conf').with_content(
+        %r{^#Managed by puppet, any changes will be overwritten$\n\n\[logging\]\nadmin_server = FILE:\/var\/logging\/admin_server_only.log\n$},
+      )
+    end
+  end
+
+  context 'with logging_krb524d parameter only set (logging_default, logging_kdc, and logging_admin_server are unset (empty strings))' do
+    let :params do
+      {
+        logging_default:      '',
+        logging_kdc:          '',
+        logging_admin_server: '',
+        logging_krb524d:      'FILE:/var/logging/krb524d_only.log',
+      }
+    end
+
+    it do
+      is_expected.to contain_file('krb5conf').with_content(
+        %r{^#Managed by puppet, any changes will be overwritten$\n\n\[logging\]\nkrb524d = FILE:\/var\/logging\/krb524d_only.log\n$},
+      )
+    end
+  end
+
+  context 'with default_realm parameter set to TEST.ING' do
+    let(:params) { { default_realm: 'TEST.ING' } }
+
+    it { is_expected.to contain_file('krb5conf').with_content(krb5conf_default_content + "\n\[libdefaults\]\ndefault_realm = TEST.ING\n") }
+  end
+
+  context 'with dns_lookup_realm parameter set to true' do
+    let(:params) { { dns_lookup_realm: 'true' } }
+
+    it { is_expected.to contain_file('krb5conf').with_content(krb5conf_default_content + "\n\[libdefaults\]\ndns_lookup_realm = true\n") }
+  end
+
+  context 'with dns_lookup_kdc parameter set to true' do
+    let(:params) { { dns_lookup_kdc: 'true' } }
+
+    it { is_expected.to contain_file('krb5conf').with_content(krb5conf_default_content + "\n\[libdefaults\]\ndns_lookup_kdc = true\n") }
+  end
+
+  context 'with ticket_lifetime parameter set to 242h' do
+    let(:params) { { ticket_lifetime: '242h' } }
+
+    it { is_expected.to contain_file('krb5conf').with_content(krb5conf_default_content + "\n\[libdefaults\]\nticket_lifetime = 242h\n") }
+  end
+
+  context 'with default_ccache_name parameter set to FILE:/test/ing_%{uid}' do
+    let(:params) { { default_ccache_name: 'FILE:/test/ing_%{uid}' } }
+
+    it { is_expected.to contain_file('krb5conf').with_content(krb5conf_default_content + "\n\[libdefaults\]\ndefault_ccache_name = FILE:\/test\/ing_%{uid}\n") }
+  end
+
+  context 'with default_keytab_name parameter set to /test/ing.keytab' do
+    let(:params) { { default_keytab_name: '/test/ing.keytab' } }
+
+    it { is_expected.to contain_file('krb5conf').with_content(krb5conf_default_content + "\n\[libdefaults\]\ndefault_keytab_name = /test/ing.keytab\n") }
+  end
+
+  context 'with forwardable parameter set to false' do
+    let(:params) { { forwardable: 'false' } }
+
+    it { is_expected.to contain_file('krb5conf').with_content(krb5conf_default_content + "\n\[libdefaults\]\nforwardable = false\n") }
+  end
+
+  context 'with allow_weak_crypto parameter set to true' do
+    let(:params) { { allow_weak_crypto: 'true' } }
+
+    it { is_expected.to contain_file('krb5conf').with_content(krb5conf_default_content + "\n\[libdefaults\]\nallow_weak_crypto = true\n") }
+  end
+
+  context 'with proxiable parameter set to false' do
+    let(:params) { { proxiable: 'false' } }
+
+    it { is_expected.to contain_file('krb5conf').with_content(krb5conf_default_content + "\n\[libdefaults\]\nproxiable = false\n") }
+  end
+
+  context 'with rdns parameter set to true' do
+    let(:params) { { rdns: 'true' } }
+
+    it { is_expected.to contain_file('krb5conf').with_content(krb5conf_default_content + "\n\[libdefaults\]\nrdns = true\n") }
+  end
+
+  context 'with default_tkt_enctypes parameter set to aes242-cts' do
+    let(:params) { { default_tkt_enctypes: 'aes242-cts' } }
+
+    it { is_expected.to contain_file('krb5conf').with_content(krb5conf_default_content + "\n\[libdefaults\]\ndefault_tkt_enctypes = aes242-cts\n") }
+  end
+
+  context 'with default_tgs_enctypes parameter set to aes242-cts' do
+    let(:params) { { default_tgs_enctypes: 'aes242-cts' } }
+
+    it { is_expected.to contain_file('krb5conf').with_content(krb5conf_default_content + "\n\[libdefaults\]\ndefault_tgs_enctypes = aes242-cts\n") }
+  end
+
+  context 'with appdefaults parameter set to a valid hash and sorts the output' do
+    let :params do
+      {
+        appdefaults: {
+          'test'              => {
+            'debug'           => 'false',
+            'ticket_lifetime' => '36000',
+            'renew_lifetime'  => '36000',
+            'forwardable'     => 'true',
+            'krb4_convert'    => 'false',
+          },
+        },
+      }
+    end
+
+    hash_content = <<-END.gsub(%r{^\s+\|}, '')
+      |
+      |[appdefaults]
+      |test = {
+      |         debug = false
+      |         forwardable = true
+      |         krb4_convert = false
+      |         renew_lifetime = 36000
+      |         ticket_lifetime = 36000
+      |}
+    END
+
+    it { is_expected.to contain_file('krb5conf').with_content(krb5conf_default_content + hash_content) }
+  end
+
+  context 'with realms parameter set to a valid hash and sorts the output' do
+    let :params do
+      {
+        realms: {
+          'TEST2.ING' => {
+            'default_domain' => 'test2.ing',
+            'kdc'            => ['kdc1.test2.ing:242', 'kdc2.test2.ing:242'],
+            'admin_server'   => ['kdc1.test2.ing:23', 'kdc2.test2.ing:23'],
+          },
+          'TEST1.ING' => {
+            'default_domain' => 'test1.ing',
+            'kdc'            => ['kdc1.test1.ing:242', 'kdc2.test1.ing:242'],
+            'admin_server'   => ['kdc1.test1.ing:23', 'kdc2.test1.ing:23'],
+          },
+        },
+      }
+    end
+
+    hash_content = <<-END.gsub(%r{^\s+\|}, '')
+      |
+      |[realms]
+      |TEST1.ING = {
+      |  admin_server = kdc1.test1.ing:23
+      |  admin_server = kdc2.test1.ing:23
+      |  default_domain = test1.ing
+      |  kdc = kdc1.test1.ing:242
+      |  kdc = kdc2.test1.ing:242
+      |}
+      |TEST2.ING = {
+      |  admin_server = kdc1.test2.ing:23
+      |  admin_server = kdc2.test2.ing:23
+      |  default_domain = test2.ing
+      |  kdc = kdc1.test2.ing:242
+      |  kdc = kdc2.test2.ing:242
+      |}
+    END
+
+    it { is_expected.to contain_file('krb5conf').with_content(krb5conf_default_content + hash_content) }
+  end
+
+  context 'with domain_realm parameter set to a valid hash and sorts the output' do
+    let :params do
+      {
+        domain_realm: {
+          'test2.ing' => 'TEST2.ING',
+          'test1.ing' => 'TEST1.ING',
+
+        },
+      }
+    end
+
+    hash_content = <<-END.gsub(%r{^\s+\|}, '')
+      |
+      |[domain_realm]
+      |.test1.ing = TEST1.ING
+      |test1.ing = TEST1.ING
+      |.test2.ing = TEST2.ING
+      |test2.ing = TEST2.ING
+    END
+
+    it { is_expected.to contain_file('krb5conf').with_content(krb5conf_default_content + hash_content) }
+  end
+
+  context 'with package parameter set to testing' do
+    let(:params) { { package: 'testing' } }
+
+    it { is_expected.to contain_package('testing') }
+  end
+
+  context 'with krb5conf_file parameter set to /test/ing' do
+    let(:params) { { krb5conf_file: '/test/ing' } }
+
+    it { is_expected.to contain_file('krb5conf').with_path('/test/ing') }
+  end
+
+  context 'with krb5conf_ensure parameter set to file' do
+    let(:params) { { krb5conf_ensure: 'file' } }
+
+    it { is_expected.to contain_file('krb5conf').with_ensure('file') }
+  end
+
+  context 'with krb5conf_owner parameter set to tester' do
+    let(:params) { { krb5conf_owner: 'tester' } }
+
+    it { is_expected.to contain_file('krb5conf').with_owner('tester') }
+  end
+
+  context 'with krb5conf_group parameter set to tester' do
+    let(:params) { { krb5conf_group: 'tester' } }
+
+    it { is_expected.to contain_file('krb5conf').with_group('tester') }
+  end
+
+  context 'with krb5conf_mode parameter set to 0242' do
+    let(:params) { { krb5conf_mode: '0242' } }
+
+    it { is_expected.to contain_file('krb5conf').with_mode('0242') }
+  end
+
+  context 'with krb5key_link_target parameter set to /test/ing' do
+    let(:params) { { krb5key_link_target: '/test/ing' } }
+
+    it {
+      is_expected.to contain_file('krb5keytab_file').only_with(
+        'ensure' => 'link',
+        'path'   => '/etc/krb5.keytab',
+        'target' => '/test/ing',
+      )
+    }
+
+    it { is_expected.to contain_file('krb5keytab_file').with_target('/test/ing') }
+  end
+
+  context 'on unsupported Solaris with package set' do
+    let :facts do
+      {
+        osfamily: 'Solaris',
+        kernelrelease: '5.8',
+      }
+    end
+    let(:params) { { package: 'solaris-58-krb5-package' } }
+
+    it { is_expected.to contain_package('solaris-58-krb5-package') }
+  end
+
+  context 'on unsupported osfamily with package set' do
+    let(:facts) { { osfamily: 'WeirdOS' } }
+    let(:params) { { package: 'weird-krb5-package' } }
+
+    it { is_expected.to contain_package('weird-krb5-package') }
+  end
+
+  context 'with default params on unsupported Solaris version' do
+    let :facts do
+      {
+        osfamily: 'Solaris',
+        kernelrelease: '5.8',
+      }
+    end
+
+    it 'fails' do
+      expect {
+        is_expected.to contain_class('krb5')
+      }.to raise_error(Puppet::Error,
+                       %r{krb5 only supports default package names for Solaris 5\.10 and 5\.11\. Detected kernelrelease is <5\.8>\. Please specify package name with the \$package variable\.})
+    end
+  end
+
+  context 'with default params on unsupported osfamily' do
+    let(:facts) { { osfamily: 'WeirdOS' } }
+
+    it 'fails' do
+      expect {
+        is_expected.to contain_class('krb5')
+      }.to raise_error(Puppet::Error,
+                       %r{krb5 only supports default package names for Debian, RedHat, Suse and Solaris\. Detected osfamily is <WeirdOS>\. Please specify package name with the \$package variable\.})
+    end
   end
 
   context 'with krb5key_link_target set to <invalid>' do
-    let(:facts) do
-      {
-        :osfamily => 'RedHat',
-      }
-    end
-    let(:params) do
-      {
-        :krb5key_link_target => 'relactive/path/keytab',
-      }
-    end
+    let(:params) { { krb5key_link_target: 'relactive/path/keytab' } }
 
-    it 'should fail' do
+    it 'fails' do
       expect {
-        should contain_class('krb5')
-}.to raise_error(Puppet::Error,/"relactive\/path\/keytab" is not an absolute path/)
+        is_expected.to contain_class('krb5')
+      }.to raise_error(Puppet::Error, %r{"relactive\/path\/keytab" is not an absolute path})
     end
   end
 
-  context 'with logging parameters that have default values set to <> (overriding default values)' do
-    let(:facts) do
-      {
-        :osfamily => 'RedHat',
-      }
-    end
-    let(:params) do
-      {
-        :logging_default      => '',
-        :logging_kdc          => '',
-        :logging_admin_server => '',
-      }
-    end
-    it { should contain_class('krb5') }
-    it { should contain_package('krb5-libs') }
-    it { should contain_file('krb5conf').with({
-      'path'   => '/etc/krb5.conf',
-      'ensure' => 'present',
-      'owner'  => 'root',
-      'group'  => 'root',
-      'mode'   => '0644',
-    }) }
+  describe 'variable data type and content validations' do
+    validations = {
+      'absolute_path' => {
+        name:    ['krb5key_link_target'], # add 'krb5conf_file'
+        valid:   ['/absolute/filepath', '/absolute/directory/'],
+        invalid: ['../invalid', 3, 2.42, ['array'], { 'ha' => 'sh' }, true, false, nil],
+        message: 'is not an absolute path', # source: stdlib
+      },
+      'array/string' => {
+        name:    ['package'],
+        valid:   ['string', ['array']],
+        invalid: [], # [{ 'ha' => 'sh' }, 3, 2.42, true], <- should become this after implementation
+        message: '', # source:
+      },
+      'boolean / stringified boolean' => {
+        name:    ['dns_lookup_realm', 'dns_lookup_kdc', 'forwardable', 'allow_weak_crypto', 'proxiable', 'rdns'],
+        valid:   [true, false, 'true', 'false'],
+        invalid: [], # ['string', ['array'], { 'ha' => 'sh' }, 3, 2.42, 'false'], <- should become this after implementation
+        message: '', # source:
+      },
+      'hash' => {
+        name:    ['realms', 'appdefaults', 'domain_realm'],
+        valid:   [], # valid hashes are to complex to block test them here. They should have their own tests anyway.
+        invalid: [], # ['string', [array], 3, 2.42, true], <- should become this after implementation
+        message: '', # source:
+      },
+      'string' => {
+        name:    ['logging_default', 'logging_kdc', 'logging_admin_server', 'logging_krb524d', 'default_realm', 'ticket_lifetime', 'default_ccache_name',
+                  'default_keytab_name', 'default_tkt_enctypes', 'default_tgs_enctypes', 'package_adminfile', 'package_source', 'krb5conf_owner', 'krb5conf_group'],
+        valid:   ['string'],
+        invalid: [], # [['array'], { 'ha' => 'sh' }, 3, 2.42, false], <- should become this after implementation
+        message: '', # source:
+      },
+      'string for file ensure' => {
+        name:    ['krb5conf_ensure'],
+        valid:   ['present', 'absent', 'file', 'directory', 'link'],
+        invalid: [], # [['array'], { 'ha' => 'sh' }, 3, 2.42, false], <- should become this after implementation
+        message: '', # source:
+      },
+      'string for package provider' => {
+        name:    ['package_provider'],
+        valid:   ['sun', 'pkg'],
+        invalid: [], # ['string', [array], { 'ha' => 'sh' }, 3, 2.42, true], <- should become this after implementation
+        message: '', # source:
+      },
+      'string for service mode' => {
+        name:    ['krb5conf_mode'],
+        valid:   ['0777', '0644', '0242'],
+        invalid: [], # ['0999', [array], { 'ha' => 'sh' }, 3, 2.42, true], <- should become this after implementation
+        message: 'expects a match for Pattern\[\/\^\[0-7\]\{4\}\$\/\]',
+      },
+    }
 
-    it { should contain_file('krb5conf').with_content("#Managed by puppet, any changes will be overwritten\n") }
-  end
+    validations.sort.each do |type, var|
+      mandatory_params = {} if mandatory_params.nil?
+      var[:name].each do |var_name|
+        var[:params] = {} if var[:params].nil?
+        var[:valid] = {} if var[:valid].nil?
+        var[:invalid] = {} if var[:invalid].nil?
 
+        var[:valid].each do |valid|
+          context "when #{var_name} (#{type}) is set to valid #{valid} (as #{valid.class})" do
+            let(:facts) { [mandatory_facts, var[:facts]].reduce(:merge) } unless var[:facts].nil?
+            let(:params) { [mandatory_params, var[:params], { :"#{var_name}" => valid }].reduce(:merge) }
+
+            it { is_expected.to compile }
+          end
+        end
+
+        var[:invalid].each do |invalid|
+          context "when #{var_name} (#{type}) is set to invalid #{invalid} (as #{invalid.class})" do
+            let(:params) { [mandatory_params, var[:params], { :"#{var_name}" => invalid }].reduce(:merge) }
+
+            it 'fails' do
+              expect { is_expected.to contain_class(:subject) }.to raise_error(Puppet::Error, %r{#{var[:message]}})
+            end
+          end
+        end
+      end # var[:name].each
+    end # validations.sort.each
+  end # describe 'variable type and content validations'
 end

--- a/spec/fixtures/krb5.conf.defaults
+++ b/spec/fixtures/krb5.conf.defaults
@@ -1,6 +1,0 @@
-#Managed by puppet, any changes will be overwritten
-
-[logging]
-default = FILE:/var/log/krb5libs.log
-kdc = FILE:/var/log/krb5kdc.log
-admin_server = FILE:/var/log/kadmind.log

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,14 @@
+RSpec.configure do |config|
+  config.mock_with :rspec
+end
+
 require 'puppetlabs_spec_helper/module_spec_helper'
 
 RSpec.configure do |config|
   config.before :each do
     Puppet[:parser] = 'future' if ENV['PARSER'] == 'future'
   end
+  config.default_facts = {
+    osfamily: 'RedHat',
+  }
 end

--- a/templates/krb5.conf.erb
+++ b/templates/krb5.conf.erb
@@ -15,7 +15,7 @@ admin_server = <%= @logging_admin_server %>
 krb524d = <%= @logging_krb524d %>
 <% end -%>
 <% end -%>
-<% if @default_realm or @dns_lookup_realm or @dns_lookup_kdc or @ticket_lifetime or @default_keytab_name or @forwardable or @allow_weak_crypto or @proxiable or @rdns -%>
+<% if @default_realm or @dns_lookup_realm or @dns_lookup_kdc or @ticket_lifetime or @default_ccache_name or @default_keytab_name or @forwardable or @allow_weak_crypto or @proxiable or @rdns or @default_tkt_enctypes or @default_tgs_enctypes -%>
 
 [libdefaults]
 <% if @default_realm -%>


### PR DESCRIPTION
- add missing tests to cover each functionality in code and template
- use specific tests for each individual functionality
- use rubocop with PDK 1.18.0 settings
- add placeholder tests for functionality to be added to code
- allign error messages
- add missing parameter support to template logic
- removes deprecation warning in test runs
  (see https://github.com/puppetlabs/puppetlabs_spec_helper#mock_with)