### PR TITLE
Do not sort Hash to keep specific ordering in results

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ test = {
 
 ---
 #### domain_realm
-Content for `[domain_realm]` section of `krb5.conf`. List of domain realms (hash with nested arrays).
+Content for `[domain_realm]` section of `krb5.conf`. List of domain realms (hash with nested arrays). Order is retained in the result.
 
 - Default: **{}**
 

--- a/README.md
+++ b/README.md
@@ -150,29 +150,29 @@ EXAMPLE.COM = {
 
 ---
 #### appdefaults (type: Hash)
-Content for `[appdefaults]` section of `krb5.conf`. List of defaults for apps (hash with nested arrays).
+Content for `[appdefaults]` section of `krb5.conf`. List of defaults for apps (hash with nested arrays). Order is retained in the result.
 
 - Default: **{}**
 
 ##### Example using Hiera
 ```yaml
 krb5::appdefaults:
-  pam:
-    'debug': 'false'
+  test:
     'ticket_lifetime': '36000'
-    'renew_lifetime': '36000'
     'forwardable': 'true'
+    'renew_lifetime': '36000'
     'krb4_convert': 'false'
+    'debug': 'false'
 ```
 Create this `[appdefaults]` section in `krb5.conf`.
 ```
 [appdefaults]
-pam = {
-         debug = false
-         forwardable = true
-         krb4_convert = false
-         renew_lifetime = 36000
+test = {
          ticket_lifetime = 36000
+         forwardable = true
+         renew_lifetime = 36000
+         krb4_convert = false
+         debug = false
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Value for `default_tgs_enctypes` in `[libdefaults]` section of `krb5.conf`.
 
 ---
 #### realms (type: Hash)
-Content for `[realms]` section of `krb5.conf`. List of kerberos domains (hash with nested arrays).
+Content for `[realms]` section of `krb5.conf`. List of kerberos domains (hash with nested arrays). Order is retained in the result.
 
 - Default: **{}**
 
@@ -140,11 +140,11 @@ Create this `[realms]` section in `krb5.conf`.
 ```
 [realms]
 EXAMPLE.COM = {
-  admin_server = kdc1.example.com:749
-  admin_server = kdc2.example.com:749
   default_domain = example.com
   kdc = kdc1.example.com:88
   kdc = kdc2.example.com:88
+  admin_server = kdc1.example.com:749
+  admin_server = kdc2.example.com:749
 }
 ```
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -373,7 +373,7 @@ describe 'krb5', type: :class do
     it { is_expected.to contain_file('krb5conf').with_content(krb5conf_default_content + "\n\[libdefaults\]\ndefault_tgs_enctypes = aes242-cts\n") }
   end
 
-  context 'with appdefaults parameter set to a valid hash and does not sort the output' do
+  context 'with appdefaults parameter set to a valid hash and order is retained in the output' do
     let :params do
       {
         appdefaults: {
@@ -403,7 +403,7 @@ describe 'krb5', type: :class do
     it { is_expected.to contain_file('krb5conf').with_content(krb5conf_default_content + hash_content) }
   end
 
-  context 'with realms parameter set to a valid hash and does not sorts the output' do
+  context 'with realms parameter set to a valid hash and order is retained in the output' do
     let :params do
       {
         realms: {
@@ -443,7 +443,7 @@ describe 'krb5', type: :class do
     it { is_expected.to contain_file('krb5conf').with_content(krb5conf_default_content + hash_content) }
   end
 
-  context 'with domain_realm parameter set to a valid hash and sorts the output' do
+  context 'with domain_realm parameter set to a valid hash and order is retained in the output' do
     let :params do
       {
         domain_realm: {
@@ -457,10 +457,10 @@ describe 'krb5', type: :class do
     hash_content = <<-END.gsub(%r{^\s+\|}, '')
       |
       |[domain_realm]
-      |.test1.ing = TEST1.ING
-      |test1.ing = TEST1.ING
       |.test2.ing = TEST2.ING
       |test2.ing = TEST2.ING
+      |.test1.ing = TEST1.ING
+      |test1.ing = TEST1.ING
     END
 
     it { is_expected.to contain_file('krb5conf').with_content(krb5conf_default_content + hash_content) }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -403,7 +403,7 @@ describe 'krb5', type: :class do
     it { is_expected.to contain_file('krb5conf').with_content(krb5conf_default_content + hash_content) }
   end
 
-  context 'with realms parameter set to a valid hash and sorts the output' do
+  context 'with realms parameter set to a valid hash and does not sorts the output' do
     let :params do
       {
         realms: {
@@ -424,19 +424,19 @@ describe 'krb5', type: :class do
     hash_content = <<-END.gsub(%r{^\s+\|}, '')
       |
       |[realms]
-      |TEST1.ING = {
-      |  admin_server = kdc1.test1.ing:23
-      |  admin_server = kdc2.test1.ing:23
-      |  default_domain = test1.ing
-      |  kdc = kdc1.test1.ing:242
-      |  kdc = kdc2.test1.ing:242
-      |}
       |TEST2.ING = {
-      |  admin_server = kdc1.test2.ing:23
-      |  admin_server = kdc2.test2.ing:23
       |  default_domain = test2.ing
       |  kdc = kdc1.test2.ing:242
       |  kdc = kdc2.test2.ing:242
+      |  admin_server = kdc1.test2.ing:23
+      |  admin_server = kdc2.test2.ing:23
+      |}
+      |TEST1.ING = {
+      |  default_domain = test1.ing
+      |  kdc = kdc1.test1.ing:242
+      |  kdc = kdc2.test1.ing:242
+      |  admin_server = kdc1.test1.ing:23
+      |  admin_server = kdc2.test1.ing:23
       |}
     END
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -410,12 +410,12 @@ describe 'krb5', type: :class do
           'TEST2.ING' => {
             'default_domain' => 'test2.ing',
             'kdc'            => ['kdc1.test2.ing:242', 'kdc2.test2.ing:242'],
-            'admin_server'   => ['kdc1.test2.ing:23', 'kdc2.test2.ing:23'],
+            'admin_server'   => ['kdc2.test2.ing:23', 'kdc1.test2.ing:23'],
           },
           'TEST1.ING' => {
-            'default_domain' => 'test1.ing',
-            'kdc'            => ['kdc1.test1.ing:242', 'kdc2.test1.ing:242'],
+            'kdc'            => ['kdc2.test1.ing:242', 'kdc1.test1.ing:242'],
             'admin_server'   => ['kdc1.test1.ing:23', 'kdc2.test1.ing:23'],
+            'default_domain' => 'test1.ing',
           },
         },
       }
@@ -428,15 +428,15 @@ describe 'krb5', type: :class do
       |  default_domain = test2.ing
       |  kdc = kdc1.test2.ing:242
       |  kdc = kdc2.test2.ing:242
-      |  admin_server = kdc1.test2.ing:23
       |  admin_server = kdc2.test2.ing:23
+      |  admin_server = kdc1.test2.ing:23
       |}
       |TEST1.ING = {
-      |  default_domain = test1.ing
-      |  kdc = kdc1.test1.ing:242
       |  kdc = kdc2.test1.ing:242
+      |  kdc = kdc1.test1.ing:242
       |  admin_server = kdc1.test1.ing:23
       |  admin_server = kdc2.test1.ing:23
+      |  default_domain = test1.ing
       |}
     END
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -373,16 +373,16 @@ describe 'krb5', type: :class do
     it { is_expected.to contain_file('krb5conf').with_content(krb5conf_default_content + "\n\[libdefaults\]\ndefault_tgs_enctypes = aes242-cts\n") }
   end
 
-  context 'with appdefaults parameter set to a valid hash and sorts the output' do
+  context 'with appdefaults parameter set to a valid hash and does not sort the output' do
     let :params do
       {
         appdefaults: {
           'test'              => {
-            'debug'           => 'false',
             'ticket_lifetime' => '36000',
-            'renew_lifetime'  => '36000',
             'forwardable'     => 'true',
+            'renew_lifetime'  => '36000',
             'krb4_convert'    => 'false',
+            'debug'           => 'false',
           },
         },
       }
@@ -392,11 +392,11 @@ describe 'krb5', type: :class do
       |
       |[appdefaults]
       |test = {
-      |         debug = false
-      |         forwardable = true
-      |         krb4_convert = false
-      |         renew_lifetime = 36000
       |         ticket_lifetime = 36000
+      |         forwardable = true
+      |         renew_lifetime = 36000
+      |         krb4_convert = false
+      |         debug = false
       |}
     END
 

--- a/spec/fixtures/krb5.conf.allset
+++ b/spec/fixtures/krb5.conf.allset
@@ -23,10 +23,10 @@ default_tgs_enctypes = aes128-cts
 [appdefaults]
 pam = {
          debug = false
+         ticket_lifetime = 36000
+         renew_lifetime = 36000
          forwardable = true
          krb4_convert = false
-         renew_lifetime = 36000
-         ticket_lifetime = 36000
 }
 
 [realms]

--- a/spec/fixtures/krb5.conf.allset
+++ b/spec/fixtures/krb5.conf.allset
@@ -30,17 +30,17 @@ pam = {
 }
 
 [realms]
-ANOTHER.EXAMPLE.COM = {
-  admin_server = kdc1.another.example.com:749
-  default_domain = another.example.com
-  kdc = kdc1.another.example.com:88
-}
 EXAMPLE.COM = {
-  admin_server = kdc1.example.com:749
-  admin_server = kdc2.example.com:749
   default_domain = example.com
   kdc = kdc1.example.com:88
   kdc = kdc2.example.com:88
+  admin_server = kdc1.example.com:749
+  admin_server = kdc2.example.com:749
+}
+ANOTHER.EXAMPLE.COM = {
+  default_domain = another.example.com
+  kdc = kdc1.another.example.com:88
+  admin_server = kdc1.another.example.com:749
 }
 
 [domain_realm]

--- a/templates/krb5.conf.erb
+++ b/templates/krb5.conf.erb
@@ -87,11 +87,11 @@ default_tgs_enctypes = <%= @default_tgs_enctypes %>
 <% if @realms != {} -%>
 
 [realms]
-<%   @realms.sort.each do |key, hash| -%>
+<%   @realms.each do |key, hash| -%>
 <%= key %> = {
-<%     hash.sort.each do |option, values| -%>
+<%     hash.each do |option, values| -%>
 <%       if values.is_a?(Array) -%>
-<%         values.sort.each do |value| -%>
+<%         values.each do |value| -%>
   <%= option %> = <%= value %>
 <%       end -%>
 <%       else -%>

--- a/templates/krb5.conf.erb
+++ b/templates/krb5.conf.erb
@@ -104,7 +104,7 @@ default_tgs_enctypes = <%= @default_tgs_enctypes %>
 <% if @domain_realm != {} -%>
 
 [domain_realm]
-<% @domain_realm.keys.sort.each do |key| -%>
+<% @domain_realm.keys.each do |key| -%>
 .<%= key %> = <%= @domain_realm[key] %>
 <%= key %> = <%= @domain_realm[key] %>
 <% end -%>

--- a/templates/krb5.conf.erb
+++ b/templates/krb5.conf.erb
@@ -76,9 +76,9 @@ default_tgs_enctypes = <%= @default_tgs_enctypes %>
 <% if @appdefaults != {} -%>
 
 [appdefaults]
-<% @appdefaults.keys.sort.each do |key| -%>
+<% @appdefaults.keys.each do |key| -%>
 <%= key %> = {
-<% @appdefaults[key].keys.sort.each do |subkey| -%>
+<% @appdefaults[key].keys.each do |subkey| -%>
          <%= subkey %> = <%= @appdefaults[key][subkey] %>
 <% end -%>
 }

--- a/templates/krb5.conf.erb
+++ b/templates/krb5.conf.erb
@@ -7,18 +7,18 @@
 -%>
 
 [logging]
-<% if @logging_default != '' -%>
+<%   if @logging_default != '' -%>
 default = <%= @logging_default %>
-<% end -%>
-<% if @logging_kdc != '' -%>
+<%   end -%>
+<%   if @logging_kdc != '' -%>
 kdc = <%= @logging_kdc %>
-<% end -%>
-<% if @logging_admin_server != '' -%>
+<%   end -%>
+<%   if @logging_admin_server != '' -%>
 admin_server = <%= @logging_admin_server %>
-<% end -%>
-<% if @logging_krb524d -%>
+<%   end -%>
+<%   if @logging_krb524d -%>
 krb524d = <%= @logging_krb524d %>
-<% end -%>
+<%   end -%>
 <% end -%>
 <% if
      @default_realm or
@@ -36,53 +36,53 @@ krb524d = <%= @logging_krb524d %>
 -%>
 
 [libdefaults]
-<% if @default_realm -%>
+<%   if @default_realm -%>
 default_realm = <%= @default_realm %>
-<% end -%>
-<% if @dns_lookup_realm_string -%>
+<%   end -%>
+<%   if @dns_lookup_realm_string -%>
 dns_lookup_realm = <%= @dns_lookup_realm_string %>
-<% end -%>
-<% if @dns_lookup_kdc_string -%>
+<%   end -%>
+<%   if @dns_lookup_kdc_string -%>
 dns_lookup_kdc = <%= @dns_lookup_kdc_string %>
-<% end -%>
-<% if @ticket_lifetime -%>
+<%   end -%>
+<%   if @ticket_lifetime -%>
 ticket_lifetime = <%= @ticket_lifetime %>
-<% end -%>
-<% if @default_ccache_name -%>
+<%   end -%>
+<%   if @default_ccache_name -%>
 default_ccache_name = <%= @default_ccache_name %>
-<% end -%>
-<% if @default_keytab_name -%>
+<%   end -%>
+<%   if @default_keytab_name -%>
 default_keytab_name = <%= @default_keytab_name %>
-<% end -%>
-<% if @forwardable_string -%>
+<%   end -%>
+<%   if @forwardable_string -%>
 forwardable = <%= @forwardable_string %>
-<% end -%>
-<% if @allow_weak_crypto_string -%>
+<%   end -%>
+<%   if @allow_weak_crypto_string -%>
 allow_weak_crypto = <%= @allow_weak_crypto_string %>
-<% end -%>
-<% if @proxiable_string -%>
+<%   end -%>
+<%   if @proxiable_string -%>
 proxiable = <%= @proxiable_string %>
-<% end -%>
-<% if @rdns_string -%>
+<%   end -%>
+<%   if @rdns_string -%>
 rdns = <%= @rdns_string %>
-<% end -%>
-<% if @default_tkt_enctypes -%>
+<%   end -%>
+<%   if @default_tkt_enctypes -%>
 default_tkt_enctypes = <%= @default_tkt_enctypes %>
-<% end -%>
-<% if @default_tgs_enctypes -%>
+<%   end -%>
+<%   if @default_tgs_enctypes -%>
 default_tgs_enctypes = <%= @default_tgs_enctypes %>
-<% end -%>
+<%   end -%>
 <% end -%>
 <% if @appdefaults != {} -%>
 
 [appdefaults]
-<% @appdefaults.keys.each do |key| -%>
+<%   @appdefaults.keys.each do |key| -%>
 <%= key %> = {
-<% @appdefaults[key].keys.each do |subkey| -%>
+<%     @appdefaults[key].keys.each do |subkey| -%>
          <%= subkey %> = <%= @appdefaults[key][subkey] %>
-<% end -%>
+<%     end -%>
 }
-<% end -%>
+<%   end -%>
 <% end -%>
 <% if @realms != {} -%>
 
@@ -104,8 +104,8 @@ default_tgs_enctypes = <%= @default_tgs_enctypes %>
 <% if @domain_realm != {} -%>
 
 [domain_realm]
-<% @domain_realm.keys.each do |key| -%>
+<%   @domain_realm.keys.each do |key| -%>
 .<%= key %> = <%= @domain_realm[key] %>
 <%= key %> = <%= @domain_realm[key] %>
-<% end -%>
+<%   end -%>
 <% end -%>


### PR DESCRIPTION
Continue the [work from @trocade](https://github.com/kodguru/puppet-module-krb5/pull/17) to stop sorting $realms, $domain_realm, and $appdefaults which allows more specific configurations.
