### PR TITLE
Remove legacy function validate_absolutepath

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -171,8 +171,6 @@ class krb5 (
   }
 
   if $krb5key_link_target != undef {
-    validate_absolute_path($krb5key_link_target)
-
     file { 'krb5keytab_file':
       ensure => link,
       path   => '/etc/krb5.keytab',


### PR DESCRIPTION
On Puppet 8 this module currently fails with the error below due to use of legacy function. It is also already validated because the parameter itself is typed to Stdlib::Absolutepath.
```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Function Call, deprecation. validate_absolute_path. This method is deprecated, please use the stdlib validate_legacy function,
                    with Stdlib::Compat::Absolute_Path. There is further documentation for validate_legacy function in the README. at ["/etc/puppetlabs/code/.../krb5/manifests/init.pp", 174] on node ...```